### PR TITLE
feat: response error 객체 생성

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
@@ -29,6 +29,5 @@ public enum ErrorCode {
 		this.status = status;
 		this.code = code;
 		this.message = message;
-
 	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.ssafy.shinhanflow.config.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+/*
+ *
+ * Status code : BadRequest(400), NotFound(401),
+ *
+ *
+ *
+ *
+ * */
+@Getter
+public enum ErrorCode {
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "E1", "올바르지 않은 입력값입니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E2", "잘못된 HTTP 메서드를 호출했습니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E3", "서버 에러가 발생했습니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존재하지 않는 엔티티입니다."),
+	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "A1", "존재하지 않는 아티클입니다.");
+
+	private final String message;
+
+	private final String code;
+	private final HttpStatus status;
+
+	ErrorCode(final HttpStatus status, final String code, final String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
@@ -14,16 +14,16 @@ import lombok.Getter;
  * */
 @Getter
 public enum ErrorCode {
-	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "E1", "올바르지 않은 입력값입니다."),
-	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E2", "잘못된 HTTP 메서드를 호출했습니다."),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E3", "서버 에러가 발생했습니다."),
-	NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존재하지 않는 엔티티입니다."),
-	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "A1", "존재하지 않는 아티클입니다.");
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "4001", "잘못된 HTTP 메서드를 호출했습니다."),
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "4002", "올바르지 않은 입력값입니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "4003", "존재하지 않는 엔티티입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "서버 에러가 발생했습니다.")
+	;
 
-	private final String message;
-
-	private final String code;
 	private final HttpStatus status;
+	private final String message;
+	private final String code;
+
 
 	ErrorCode(final HttpStatus status, final String code, final String message) {
 		this.status = status;

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorResponse.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorResponse.java
@@ -16,16 +16,8 @@ public class ErrorResponse {
 		this.message = code.getMessage();
 	}
 
-	public ErrorResponse(final ErrorCode code, final String message) {
-		this.code = code.getCode();
-		this.message = message;
-	}
-
 	public static ErrorResponse of(final ErrorCode code) {
 		return new ErrorResponse(code);
 	}
 
-	public static ErrorResponse of(final ErrorCode code, final String message) {
-		return new ErrorResponse(code, message);
-	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorResponse.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorResponse.java
@@ -1,0 +1,31 @@
+package com.ssafy.shinhanflow.config.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+	private String code;
+	private String message;
+
+	private ErrorResponse(final ErrorCode code) {
+		this.code = code.getCode();
+		this.message = code.getMessage();
+	}
+
+	public ErrorResponse(final ErrorCode code, final String message) {
+		this.code = code.getCode();
+		this.message = message;
+	}
+
+	public static ErrorResponse of(final ErrorCode code) {
+		return new ErrorResponse(code);
+	}
+
+	public static ErrorResponse of(final ErrorCode code, final String message) {
+		return new ErrorResponse(code, message);
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/GlobalExceptionHandler.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/GlobalExceptionHandler.java
@@ -1,4 +1,40 @@
 package com.ssafy.shinhanflow.config.error;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.ssafy.shinhanflow.config.error.exception.BusinessBaseException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ControllerAdvice // 모든 컨트롤러에서 발생하는 예외를 잡아서 처리
 public class GlobalExceptionHandler {
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	protected ResponseEntity<ErrorResponse> handle(HttpRequestMethodNotSupportedException e){
+		log.error("HttpRequestMethodNotSupportedException", e);
+		return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED);
+	}
+
+	@ExceptionHandler(BusinessBaseException.class)
+	protected ResponseEntity<ErrorResponse> handle(BusinessBaseException e){
+		log.error("BusinessException", e);
+		return createErrorResponseEntity(e.getErrorCode());
+	}
+
+	@ExceptionHandler(Exception.class)
+	protected ResponseEntity<ErrorResponse> handle(Exception e){
+		e.printStackTrace();
+		log.error("Exception", e);
+		return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
+	}
+
+	private ResponseEntity<ErrorResponse> createErrorResponseEntity(ErrorCode errorCode){
+		return new ResponseEntity<>(
+			ErrorResponse.of(errorCode),
+			errorCode.getStatus()
+		);
+	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/GlobalExceptionHandler.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/GlobalExceptionHandler.java
@@ -1,0 +1,4 @@
+package com.ssafy.shinhanflow.config.error;
+
+public class GlobalExceptionHandler {
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/SuccessResponse.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/SuccessResponse.java
@@ -1,0 +1,26 @@
+package com.ssafy.shinhanflow.config.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SuccessResponse<T> {
+
+	private HttpStatus code;
+	private String message;
+	private T data;
+
+	private SuccessResponse(HttpStatus code, String message, T data){
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> SuccessResponse<T> of(T data){
+		return new SuccessResponse<>(HttpStatus.OK, "ok", data);
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/BadRequestException.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.ssafy.shinhanflow.config.error.exception;
+
+import com.ssafy.shinhanflow.config.error.ErrorCode;
+
+public class BadRequestException extends  BusinessBaseException{
+
+	public BadRequestException(String message, ErrorCode errorCode) {
+		super(message, errorCode);
+	}
+
+	public BadRequestException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/BusinessBaseException.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/BusinessBaseException.java
@@ -1,0 +1,21 @@
+package com.ssafy.shinhanflow.config.error.exception;
+
+import com.ssafy.shinhanflow.config.error.ErrorCode;
+
+public class BusinessBaseException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public BusinessBaseException(String message, final ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public BusinessBaseException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/GlobalExceptionHandler.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
-package com.ssafy.shinhanflow.config.error;
+package com.ssafy.shinhanflow.config.error.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.ssafy.shinhanflow.config.error.ErrorCode;
+import com.ssafy.shinhanflow.config.error.ErrorResponse;
 import com.ssafy.shinhanflow.config.error.exception.BusinessBaseException;
 
 import lombok.extern.slf4j.Slf4j;

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/NoResourceFoundException.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/NoResourceFoundException.java
@@ -1,0 +1,4 @@
+package com.ssafy.shinhanflow.config.error.exception;
+
+public class NoResourceFoundException {
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/NotFoundException.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.ssafy.shinhanflow.config.error.exception;
+
+import com.ssafy.shinhanflow.config.error.ErrorCode;
+
+public class NotFoundException extends BusinessBaseException {
+
+	public NotFoundException(ErrorCode errorCode) {
+		super(errorCode.getMessage(), errorCode);
+	}
+
+	public NotFoundException() {
+		super(ErrorCode.NOT_FOUND);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용
### 성공응답과 에러 응답에 대한 객체를 생성했습니다.
1. 성공응답시에는 `SuccessResponse.of(T data);` 메서드를 호출하여 클라이언트에 return 하면됩니다. 이때, T 타입의 data에는 DTO 형식으로 넣어주시고 별다른 응답이 없다면 Boolean 타입으로 true를 반환해주세요.
2. 에러는 throw 해주시면 전부 캐치합니다.  별도의 try catch문이나 throw를 명시하지 않아도 됩니다.
각 에러에 맞는 에러객체를 생성하고, 파라미터에는 에러의 내용을 미리 정의한 ErrorCode enum의 상수가 들어가게 됩니다.
`throw new BadRequestException(Errorcode.NOTFOUND);`
컨트롤러에서 호출하는 로직이 아니라면 적용되지 않습니다.(JWT, 별도 스케줄링 등)


## 💬리뷰 요구사항(선택)
> 해당내용 꼭 숙지하고 예외처리, 성공처리 해주세요.
> 이해가 안되면 물어보세요!!
