### PR TITLE
feat: 트리거 계좌, (대출, 예금, 적금) 설정 화면

### DIFF
--- a/fe/lib/auth/provider/widget/widget/login_form_provider.dart
+++ b/fe/lib/auth/provider/widget/widget/login_form_provider.dart
@@ -3,7 +3,9 @@ import 'dart:developer';
 import 'package:flutter/cupertino.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shinhan_flow/common/model/base_form_model.dart';
+import 'package:shinhan_flow/flow/param/trigger/trigger_param.dart';
 
+import '../../../../common/param/default_param.dart';
 import '../../../param/login_param.dart';
 
 part 'login_form_provider.g.dart';
@@ -28,6 +30,12 @@ class LoginFormModel extends LoginParam with BaseFormModel {
         email: email ?? this.email,
         password: password ?? this.password,
         valid: valid);
+  }
+
+  @override
+  DefaultParam toParam() {
+    // TODO: implement toParam
+    throw UnimplementedError();
   }
 }
 

--- a/fe/lib/auth/provider/widget/widget/sign_up_form_provider.dart
+++ b/fe/lib/auth/provider/widget/widget/sign_up_form_provider.dart
@@ -3,7 +3,9 @@ import 'dart:developer';
 import 'package:flutter/cupertino.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shinhan_flow/common/model/base_form_model.dart';
+import 'package:shinhan_flow/flow/param/trigger/trigger_param.dart';
 
+import '../../../../common/param/default_param.dart';
 import '../../../param/sign_up_param.dart';
 
 part 'sign_up_form_provider.g.dart';
@@ -52,6 +54,12 @@ class SignUpFormModel extends SignUpParam with BaseFormModel {
       valid: valid,
       validCode: validCode ?? this.validCode,
     );
+  }
+
+  @override
+  DefaultParam toParam() {
+    // TODO: implement toParam
+    throw UnimplementedError();
   }
 }
 

--- a/fe/lib/common/component/text_input_form.dart
+++ b/fe/lib/common/component/text_input_form.dart
@@ -7,6 +7,7 @@ import 'package:shinhan_flow/common/component/default_text_button.dart';
 import 'package:shinhan_flow/theme/text_theme.dart';
 
 class CustomTextFormField extends StatelessWidget {
+  final TextEditingController? textEditingController;
   final String? initialValue;
   final String? label;
   final String hintText;
@@ -30,6 +31,7 @@ class CustomTextFormField extends StatelessWidget {
     this.isMultiLine = false,
     this.keyboardType,
     this.inputFormatters,
+    this.textEditingController,
   });
 
   @override
@@ -49,6 +51,7 @@ class CustomTextFormField extends StatelessWidget {
             Expanded(
               /// constraints 으로 크기를 지정해도 align을 지정 안하면 안됨!
               child: TextFormField(
+                controller: textEditingController,
                 obscuringCharacter: '●',
                 obscureText: obscureText,
                 onChanged: onChanged,

--- a/fe/lib/common/model/base_form_model.dart
+++ b/fe/lib/common/model/base_form_model.dart
@@ -1,4 +1,8 @@
+import '../../flow/param/trigger/trigger_param.dart';
+import '../param/default_param.dart';
+
 mixin BaseFormModel {
   bool valid = false;
 
+  DefaultParam toParam();
 }

--- a/fe/lib/common/provider/router_provider.dart
+++ b/fe/lib/common/provider/router_provider.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod/riverpod.dart';
+import 'package:shinhan_flow/trigger/model/enum/product_property.dart';
 import 'package:shinhan_flow/trigger/view/account_trigger_screen.dart';
+import 'package:shinhan_flow/trigger/view/product_trigger_screen.dart';
 import 'package:shinhan_flow/trigger/view/time_trigger_screen.dart';
 import 'package:shinhan_flow/flow/view/trigger_category_screen.dart';
 import 'package:shinhan_flow/flow/view/flow_init_screen.dart';
@@ -99,6 +101,14 @@ final routerProvider = Provider<GoRouter>((ref) {
                               name: AccountTriggerScreen.routeName,
                               builder: (context, state) {
                                 return const AccountTriggerScreen();
+                              },
+                              routes: []),
+                          GoRoute(
+                              path: 'productTrigger',
+                              parentNavigatorKey: rootNavKey,
+                              name: ProductTriggerScreen.routeName,
+                              builder: (context, state) {
+                                return const ProductTriggerScreen();
                               },
                               routes: []),
                         ]),

--- a/fe/lib/flow/param/enum/flow_type.dart
+++ b/fe/lib/flow/param/enum/flow_type.dart
@@ -57,4 +57,12 @@ extension FlowExtension on FlowType {
         FlowType.dayOfMonth == this ||
         FlowType.dayOfWeek == this;
   }
+
+  bool isProductType() {
+    return FlowType.interestRate == this;
+  }
+
+  bool isExchangeType() {
+    return FlowType.exchangeRate == this;
+  }
 }

--- a/fe/lib/flow/param/trigger/trigger_param.dart
+++ b/fe/lib/flow/param/trigger/trigger_param.dart
@@ -17,12 +17,13 @@
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
+import '../../../common/param/default_param.dart';
 import '../enum/flow_type.dart';
 
 part 'trigger_param.g.dart';
 
 @JsonSerializable()
-class TriggerParam {
+class TriggerParam extends DefaultParam{
   final FlowType code;
   final TriggerBaseParam data;
 
@@ -35,6 +36,12 @@ class TriggerParam {
 
   factory TriggerParam.fromJson(Map<String, dynamic> json) =>
       _$TriggerParamFromJson(json);
+
+  @override
+  // TODO: implement props
+  List<Object?> get props => [code, data];
+
+
 }
 
 @JsonSerializable()

--- a/fe/lib/flow/param/trigger/trigger_product_param.dart
+++ b/fe/lib/flow/param/trigger/trigger_product_param.dart
@@ -1,0 +1,35 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:shinhan_flow/flow/param/trigger/trigger_param.dart';
+import 'package:shinhan_flow/trigger/model/enum/product_property.dart';
+
+import '../../provider/widget/product_trigger_form_provider.dart';
+
+part 'trigger_product_param.g.dart';
+
+@JsonSerializable()
+class TgProductParam extends TriggerBaseParam {
+  final ProductProperty? product;
+  @JsonKey(name: 'interest_rate')
+  final double? interestRate;
+
+  const TgProductParam({
+    this.product,
+    this.interestRate,
+  });
+
+  @override
+  List<Object?> get props => [
+        product,
+        interestRate,
+      ];
+
+  @override
+  Map<String, dynamic> toJson() => _$TgProductParamToJson(this);
+
+  factory TgProductParam.fromForm({required TgProductFormModel form}) {
+    return TgProductFormModel(
+      product: form.product,
+      interestRate: form.interestRate,
+    );
+  }
+}

--- a/fe/lib/flow/provider/widget/account_trigger_form_provider.dart
+++ b/fe/lib/flow/provider/widget/account_trigger_form_provider.dart
@@ -2,9 +2,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shinhan_flow/flow/model/enum/widget/trigger_enum.dart';
 import 'package:shinhan_flow/flow/param/trigger/trigger_account_param.dart';
+import 'package:shinhan_flow/flow/param/trigger/trigger_param.dart';
 import 'package:shinhan_flow/trigger/model/enum/widget/account_property.dart';
 
 import '../../../common/model/base_form_model.dart';
+import '../../../common/param/default_param.dart';
 
 part 'account_trigger_form_provider.g.dart';
 
@@ -47,6 +49,12 @@ class TgAccountFormModel extends TgAccountParam with BaseFormModel {
       valid: valid,
       thanType: thanType ?? this.thanType,
     );
+  }
+
+  @override
+  DefaultParam toParam() {
+    // TODO: implement toParam
+    throw UnimplementedError();
   }
 }
 

--- a/fe/lib/flow/provider/widget/flow_form_provider.dart
+++ b/fe/lib/flow/provider/widget/flow_form_provider.dart
@@ -6,6 +6,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shinhan_flow/common/model/base_form_model.dart';
 import 'package:shinhan_flow/flow/param/enum/flow_type.dart';
 
+import '../../../common/param/default_param.dart';
 import '../../model/enum/widget/flow_property.dart';
 import '../../param/flow_param.dart';
 import '../../param/trigger/trigger_param.dart';
@@ -44,6 +45,12 @@ class FlowFormModel extends FlowParam with BaseFormModel {
       valid: valid,
     );
   }
+
+  @override
+  DefaultParam toParam() {
+    // TODO: implement toParam
+    throw UnimplementedError();
+  }
 }
 
 @riverpod
@@ -68,7 +75,14 @@ class FlowForm extends _$FlowForm {
   void addTrigger({required TriggerParam trigger}) {
     /// final 로 설정한 List 는 add 를 하지 못하기 때문에 deepCopy 한 후 값 추가
     final triggers = state.triggers.toList();
-    triggers.removeWhere((t) => t.code.isTimeType());
+    if (trigger.code.isTimeType()) {
+      triggers.removeWhere((t) => t.code.isTimeType());
+    } else if (trigger.code.isProductType()) {
+      triggers.removeWhere((t) => t.code.isProductType());
+    } else if (trigger.code.isExchangeType()) {
+      triggers.removeWhere((t) => t.code.isExchangeType());
+    }
+
     final newTriggers = triggers..add(trigger);
     state = state.copyWith(triggers: newTriggers);
   }

--- a/fe/lib/flow/provider/widget/product_trigger_form_provider.dart
+++ b/fe/lib/flow/provider/widget/product_trigger_form_provider.dart
@@ -1,0 +1,75 @@
+import 'dart:developer';
+
+import 'package:flutter/cupertino.dart';
+import 'package:intl/intl.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shinhan_flow/flow/param/trigger/trigger_product_param.dart';
+import 'package:shinhan_flow/flow/provider/widget/flow_form_provider.dart';
+import 'package:shinhan_flow/trigger/model/enum/product_property.dart';
+
+import '../../../common/model/base_form_model.dart';
+import '../../../common/param/default_param.dart';
+import '../../../trigger/model/enum/time_category.dart';
+import '../../param/enum/flow_type.dart';
+import '../../param/trigger/trigger_date_time_param.dart';
+import '../../param/trigger/trigger_param.dart';
+
+part 'product_trigger_form_provider.g.dart';
+
+@immutable
+class TgProductFormModel extends TgProductParam with BaseFormModel {
+  TgProductFormModel({
+    bool valid = false,
+    super.product,
+    super.interestRate,
+  }) {
+    this.valid = valid;
+  }
+
+  TgProductFormModel copyWith({
+    ProductProperty? product,
+    double? interestRate,
+  }) {
+    final validProduct = product ?? this.product;
+    final validInterestRate = interestRate ?? this.interestRate;
+    final valid = validProduct != null && validInterestRate != null;
+    return TgProductFormModel(
+      valid: valid,
+      product: product ?? this.product,
+      interestRate: interestRate ?? this.interestRate,
+    );
+  }
+
+  @override
+  DefaultParam toParam() {
+    return TriggerParam(
+      code: FlowType.interestRate,
+      data: TgProductParam.fromForm(form: this),
+    );
+  }
+
+// TriggerParam toParam() {
+//   return TriggerParam(
+//     code: flowType!,
+//     data: TgDateTimeParam.fromForm(form: this),
+//   );
+// }
+}
+
+@riverpod
+class TgProductForm extends _$TgProductForm {
+  @override
+  TgProductFormModel build() {
+    return TgProductFormModel();
+  }
+
+  void update({
+    ProductProperty? property,
+    double? interestRate,
+  }) {
+    state = state.copyWith(
+      product: property,
+      interestRate: interestRate,
+    );
+  }
+}

--- a/fe/lib/flow/provider/widget/time_form_provider.dart
+++ b/fe/lib/flow/provider/widget/time_form_provider.dart
@@ -6,6 +6,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shinhan_flow/flow/provider/widget/flow_form_provider.dart';
 
 import '../../../common/model/base_form_model.dart';
+import '../../../common/param/default_param.dart';
 import '../../../trigger/model/enum/time_category.dart';
 import '../../param/enum/flow_type.dart';
 import '../../param/trigger/trigger_date_time_param.dart';
@@ -134,7 +135,7 @@ class TgDateTimeFormModel extends TgDateTimeParam with BaseFormModel {
     );
   }
 
-  TriggerParam toParam() {
+  DefaultParam toParam() {
     return TriggerParam(
       code: flowType!,
       data: TgDateTimeParam.fromForm(form: this),

--- a/fe/lib/flow/view/flow_init_screen.dart
+++ b/fe/lib/flow/view/flow_init_screen.dart
@@ -10,14 +10,17 @@ import 'package:shinhan_flow/flow/model/enum/action_category.dart';
 import 'package:shinhan_flow/flow/model/enum/trigger_category.dart';
 import 'package:shinhan_flow/flow/model/enum/widget/flow_property.dart';
 import 'package:shinhan_flow/flow/param/enum/flow_type.dart';
+import 'package:shinhan_flow/flow/param/trigger/trigger_product_param.dart';
 import 'package:shinhan_flow/flow/provider/widget/time_form_provider.dart';
 import 'package:shinhan_flow/flow/provider/widget/trigger_category_provider.dart';
 import 'package:shinhan_flow/flow/provider/widget/flow_form_provider.dart';
+import 'package:shinhan_flow/trigger/model/enum/product_property.dart';
 import 'package:shinhan_flow/trigger/view/account_trigger_screen.dart';
 import 'package:shinhan_flow/trigger/view/time_trigger_screen.dart';
 import 'package:shinhan_flow/theme/text_theme.dart';
 
 import '../../common/component/bottom_nav_button.dart';
+import '../../trigger/view/product_trigger_screen.dart';
 import '../param/trigger/trigger_date_time_param.dart';
 import '../param/trigger/trigger_param.dart';
 
@@ -285,7 +288,9 @@ class _TriggerComponent extends ConsumerWidget {
                   } else if (TriggerCategoryType.transfer == t) {
                     context.pushNamed(AccountTriggerScreen.routeName);
                   } else if (TriggerCategoryType.exchange == t) {
-                  } else {}
+                  } else {
+                    context.pushNamed(ProductTriggerScreen.routeName);
+                  }
                 },
                 visibleDelete: visibleDelete,
               ))
@@ -393,6 +398,18 @@ class _FlowInitCard extends ConsumerWidget {
             break;
           default:
             break;
+        }
+      } on Error catch (e) {
+        log("Error ${e}");
+      }
+    } else if (triggerType == TriggerCategoryType.product) {
+      final triggers = ref.watch(flowFormProvider.select((f) => f.triggers));
+      try {
+        final findTrigger =
+            triggers.singleWhere((t) => t.code == FlowType.interestRate);
+        final param = (findTrigger.data as TgProductParam);
+        if (param.product != null) {
+          content = "${param.product!.name} 금리 ${param.interestRate}%";
         }
       } on Error catch (e) {
         log("Error ${e}");

--- a/fe/lib/trigger/model/enum/product_property.dart
+++ b/fe/lib/trigger/model/enum/product_property.dart
@@ -1,0 +1,9 @@
+enum ProductProperty {
+  DEPOSIT('예금'),
+  SAVING('적금'),
+  LOAN('대출');
+
+  final String name;
+
+  const ProductProperty(this.name);
+}

--- a/fe/lib/trigger/view/exchange_trigger_screen.dart
+++ b/fe/lib/trigger/view/exchange_trigger_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ExchangeTriggerScreen extends StatelessWidget {
+  static String get routeName => 'exchange';
+
+  const ExchangeTriggerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/fe/lib/trigger/view/product_trigger_screen.dart
+++ b/fe/lib/trigger/view/product_trigger_screen.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shinhan_flow/common/component/default_appbar.dart';
+import 'package:shinhan_flow/flow/provider/widget/flow_form_provider.dart';
+import 'package:shinhan_flow/flow/provider/widget/product_trigger_form_provider.dart';
+
+import '../../common/component/bottom_nav_button.dart';
+import '../../common/component/default_text_button.dart';
+import '../../common/component/text_input_form.dart';
+import '../../flow/param/trigger/trigger_param.dart';
+import '../../theme/text_theme.dart';
+import '../model/enum/product_property.dart';
+
+class ProductTriggerScreen extends StatelessWidget {
+  static String get routeName => "product";
+
+  const ProductTriggerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      onPanDown: (v) => FocusScope.of(context).unfocus(),
+      child: Scaffold(
+        bottomNavigationBar: Consumer(
+          builder: (BuildContext context, WidgetRef ref, Widget? child) {
+            final valid = ref.watch(tgProductFormProvider).valid;
+
+            return BottomNavButton(
+              child: DefaultTextButton(
+                onPressed: valid
+                    ? () {
+                        final trigger = ref.read(tgProductFormProvider);
+
+                        ref.read(flowFormProvider.notifier).addTrigger(
+                            trigger: trigger.toParam() as TriggerParam);
+                        context.pop();
+                      }
+                    : null,
+                text: '완료',
+                able: valid,
+
+              ),
+            );
+          },
+        ),
+        body: NestedScrollView(
+            headerSliverBuilder: (_, __) {
+              return [
+                const DefaultAppBar(
+                  isSliver: true,
+                  title: '상품 조건 설정',
+                )
+              ];
+            },
+            body: CustomScrollView(
+              slivers: [
+                SliverToBoxAdapter(
+                  child: _ProductForm(),
+                )
+              ],
+            )),
+      ),
+    );
+  }
+}
+
+class _ProductForm extends ConsumerStatefulWidget {
+  const _ProductForm({super.key});
+
+  @override
+  ConsumerState<_ProductForm> createState() => _ProductFormState();
+}
+
+class _ProductFormState extends ConsumerState<_ProductForm> {
+  late final TextEditingController textEditingController;
+
+  @override
+  void initState() {
+    super.initState();
+    textEditingController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    textEditingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(tgProductFormProvider, (prev, next) {
+      if (prev?.product != next.product) {
+        textEditingController.clear();
+      }
+    });
+    final form = ref.watch(tgProductFormProvider);
+
+    final filters = ProductProperty.values
+        .map((a) => _ProductTriggerFilter(
+              isSelected: form.product == a,
+              property: a,
+              onTap: () {
+                ref.read(tgProductFormProvider.notifier).update(property: a);
+              },
+            ))
+        .toList();
+
+    return Padding(
+      padding: EdgeInsets.all(25.r),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '상품 조건',
+            style: SHFlowTextStyle.subTitle,
+          ),
+          SizedBox(height: 12.h),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: filters,
+          ),
+          SizedBox(height: 24.h),
+          Text('${form.product?.name ?? '상품'} 금리',
+              style: SHFlowTextStyle.subTitle),
+          SizedBox(height: 8.h),
+          CustomTextFormField(
+            textEditingController: textEditingController,
+            hintText: '${form.product?.name ?? '상품'} 금리를 입력해주세요.',
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter(RegExp(r"^\d?\.?\d{0,2}"),
+                  allow: true),
+              // FilteringTextInputFormatter.digitsOnly,
+            ],
+            onChanged: (v) {
+              ref.read(tgProductFormProvider.notifier).update(
+                  property: form.product,
+                  interestRate: v.isNotEmpty ? double.parse(v) : null);
+            },
+          ),
+          SizedBox(height: 16.h),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProductTriggerFilter extends StatelessWidget {
+  final ProductProperty property;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _ProductTriggerFilter({
+    super.key,
+    required this.isSelected,
+    required this.property,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        width: 85.w,
+        height: 50.h,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8.r),
+          color: isSelected ? const Color(0xFFA3C9FF) : const Color(0xFFE4ECF9),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          property.name,
+          style: SHFlowTextStyle.subTitle,
+        ),
+      ),
+    );
+  }
+}

--- a/fe/lib/trigger/view/time_trigger_screen.dart
+++ b/fe/lib/trigger/view/time_trigger_screen.dart
@@ -17,6 +17,7 @@ import 'package:table_calendar/table_calendar.dart';
 import '../../common/component/default_text_button.dart';
 import '../../common/component/table_calendar.dart';
 import '../../flow/param/enum/flow_type.dart';
+import '../../flow/param/trigger/trigger_param.dart';
 import '../model/enum/time_category.dart';
 
 class TimeTriggerScreen extends StatelessWidget {
@@ -37,9 +38,8 @@ class TimeTriggerScreen extends StatelessWidget {
                   ? () {
                       final trigger = ref.read(tgDateTimeFormProvider);
 
-                      ref
-                          .read(flowFormProvider.notifier)
-                          .addTrigger(trigger: trigger.toParam());
+                      ref.read(flowFormProvider.notifier).addTrigger(
+                          trigger: trigger.toParam() as TriggerParam);
                       context.pop();
                     }
                   : null,


### PR DESCRIPTION
1. 트리거 계좌, (대출, 예금, 적금) 설정 화면 및 상태관리 구현

## #️⃣연관된 이슈

> ex) #29 

## 📝작업 내용

> 트리거 계좌, (대출, 예금, 적금) 설정 화면 및 상태관리 구현



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
