### PR TITLE
feat: 금융망 api 오류 client에게 전달

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorResponse.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorResponse.java
@@ -16,8 +16,16 @@ public class ErrorResponse {
 		this.message = code.getMessage();
 	}
 
+	private ErrorResponse(final String code, final String message) {
+		this.code = code;
+		this.message = message;
+	}
+
 	public static ErrorResponse of(final ErrorCode code) {
 		return new ErrorResponse(code);
 	}
 
+	public static ErrorResponse of(final String code, final String message) {
+		return new ErrorResponse(code, message);
+	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/FinanceApiException.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/FinanceApiException.java
@@ -1,0 +1,17 @@
+package com.ssafy.shinhanflow.config.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class FinanceApiException extends RuntimeException {
+	final HttpStatus status = HttpStatus.valueOf(400);
+	final String errorCode;
+
+	public FinanceApiException(String errorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/GlobalExceptionHandler.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import com.ssafy.shinhanflow.config.error.ErrorCode;
 import com.ssafy.shinhanflow.config.error.ErrorResponse;
-import com.ssafy.shinhanflow.config.error.exception.BusinessBaseException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,25 +14,34 @@ import lombok.extern.slf4j.Slf4j;
 @ControllerAdvice // 모든 컨트롤러에서 발생하는 예외를 잡아서 처리
 public class GlobalExceptionHandler {
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	protected ResponseEntity<ErrorResponse> handle(HttpRequestMethodNotSupportedException e){
+	protected ResponseEntity<ErrorResponse> handle(HttpRequestMethodNotSupportedException e) {
 		log.error("HttpRequestMethodNotSupportedException", e);
 		return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED);
 	}
 
 	@ExceptionHandler(BusinessBaseException.class)
-	protected ResponseEntity<ErrorResponse> handle(BusinessBaseException e){
+	protected ResponseEntity<ErrorResponse> handle(BusinessBaseException e) {
 		log.error("BusinessException", e);
 		return createErrorResponseEntity(e.getErrorCode());
 	}
 
+	@ExceptionHandler(FinanceApiException.class)
+	protected ResponseEntity<ErrorResponse> handle(FinanceApiException e) {
+		log.error("FinanceApiException", e);
+		return new ResponseEntity<>(
+			ErrorResponse.of(e.getErrorCode(), e.getMessage()),
+			e.getStatus()
+		);
+	}
+
 	@ExceptionHandler(Exception.class)
-	protected ResponseEntity<ErrorResponse> handle(Exception e){
+	protected ResponseEntity<ErrorResponse> handle(Exception e) {
 		e.printStackTrace();
 		log.error("Exception", e);
 		return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
 	}
 
-	private ResponseEntity<ErrorResponse> createErrorResponseEntity(ErrorCode errorCode){
+	private ResponseEntity<ErrorResponse> createErrorResponseEntity(ErrorCode errorCode) {
 		return new ResponseEntity<>(
 			ErrorResponse.of(errorCode),
 			errorCode.getStatus()

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/financeapi/FinanceApiFetcher.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/financeapi/FinanceApiFetcher.java
@@ -48,7 +48,12 @@ public class FinanceApiFetcher {
 					if (clientResponse.statusCode() == HttpStatus.BAD_REQUEST) {
 						return clientResponse.bodyToMono(FinanceApiErrorBody.class)
 							.flatMap(errorBody -> {
+
 								FinanceApiErrorBody.Header header = errorBody.getHeader();
+								if (header == null) {
+									throw new FinanceApiException(errorBody.getResponseCode(),
+										errorBody.getResponseMessage());
+								}
 								throw new FinanceApiException(header.getResponseCode(), header.getResponseMessage());
 							});
 					}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/financeapi/dto/FinanceApiErrorBody.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/financeapi/dto/FinanceApiErrorBody.java
@@ -1,0 +1,19 @@
+package com.ssafy.shinhanflow.financeapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FinanceApiErrorBody {
+	@JsonProperty("Header")
+	private Header header;
+
+	@Getter
+	@NoArgsConstructor
+	public static class Header {
+		private String responseCode;
+		private String responseMessage;
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/financeapi/dto/FinanceApiErrorBody.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/financeapi/dto/FinanceApiErrorBody.java
@@ -1,12 +1,18 @@
 package com.ssafy.shinhanflow.financeapi.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class FinanceApiErrorBody {
+	// Header API가 아닌 경우
+	private String responseCode;
+	private String responseMessage;
+
+	// Header API인 경우
 	@JsonProperty("Header")
 	private Header header;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #58 

## 📝작업 내용

> 금융망 API에서 받은 에러를 client에게도 전달할 수 있도록
> 1. `GlobalExceptionHandler`를 업데이트 하고
> 2. `FinanceApiFetcher`를 업데이트 했습니다.



## 💬리뷰 요구사항(선택)

> 
