### PR TITLE
feat: financeapifetcher의 fetch 함수 에러 핸들링 업데이트

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/FinanceApiException.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/FinanceApiException.java
@@ -1,16 +1,17 @@
 package com.ssafy.shinhanflow.config.error.exception;
 
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 import lombok.Getter;
 
 @Getter
 public class FinanceApiException extends RuntimeException {
-	final HttpStatus status = HttpStatus.valueOf(400);
+	final HttpStatusCode httpStatusCode;
 	final String errorCode;
 
-	public FinanceApiException(String errorCode, String message) {
+	public FinanceApiException(HttpStatusCode httpStatusCode, String errorCode, String message) {
 		super(message);
+		this.httpStatusCode = httpStatusCode;
 		this.errorCode = errorCode;
 	}
 

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/GlobalExceptionHandler.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/exception/GlobalExceptionHandler.java
@@ -29,8 +29,10 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handle(FinanceApiException e) {
 		log.error("FinanceApiException", e);
 		return new ResponseEntity<>(
-			ErrorResponse.of(e.getErrorCode(), e.getMessage()),
-			e.getStatus()
+			ErrorResponse.of(
+				e.getErrorCode(),
+				e.getMessage()),
+			e.getHttpStatusCode()
 		);
 	}
 

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiFetcher.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiFetcher.java
@@ -41,11 +41,10 @@ public class FinanceApiFetcher {
 				.contentType(MediaType.APPLICATION_JSON)
 				.bodyValue(objectMapper.writeValueAsString(financeApiRequestDto))
 				.retrieve()
-				.onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+				.onStatus(HttpStatusCode::isError, clientResponse -> {
 					if (clientResponse.statusCode() == HttpStatus.BAD_REQUEST) {
 						return clientResponse.bodyToMono(FinanceApiErrorBody.class)
 							.flatMap(errorBody -> {
-
 								FinanceApiErrorBody.Header header = errorBody.getHeader();
 								if (header == null) {
 									throw new FinanceApiException(clientResponse.statusCode(),

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiFetcher.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiFetcher.java
@@ -1,6 +1,6 @@
 package com.ssafy.shinhanflow.util;
 
-import static com.ssafy.shinhanflow.config.error.ErrorCode.*;
+import static com.ssafy.shinhanflow.config.error.ErrorCode.INTERNAL_SERVER_ERROR;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -48,10 +48,13 @@ public class FinanceApiFetcher {
 
 								FinanceApiErrorBody.Header header = errorBody.getHeader();
 								if (header == null) {
-									throw new FinanceApiException(errorBody.getResponseCode(),
+									throw new FinanceApiException(clientResponse.statusCode(),
+										errorBody.getResponseCode(),
 										errorBody.getResponseMessage());
 								}
-								throw new FinanceApiException(header.getResponseCode(), header.getResponseMessage());
+								throw new FinanceApiException(clientResponse.statusCode(),
+									header.getResponseCode(),
+									header.getResponseMessage());
 							});
 					}
 					return clientResponse.createException().flatMap(Mono::error);

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiFetcher.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiFetcher.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
+@Component
 public class FinanceApiFetcher {
 	@Value("${finance-api.key}")
 	private String apiKey;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #73 

## 📝작업 내용

1. `FinanceApiException`이 고정된 400이 아닌 HttpStatusCode를 포함하도록 변경 (생성자에 파라미터 추가)
2. 1번 변경 사항에 의해 영향 받는 코드 update (`FinanceApiFetcher`의 `fetch` method, `GlobalExceptionHandler`)
3. `FinanceApiFetcher`가 모든 에러(4xx, 5xx)를 핸들링 하도록 update


## 💬리뷰 요구사항(선택)

