### PR TITLE
refactor: 로그인 응답 수정

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/auth/dto/LoginSuccessResponseDto.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/auth/dto/LoginSuccessResponseDto.java
@@ -1,0 +1,11 @@
+package com.ssafy.shinhanflow.auth.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class LoginSuccessResponseDto {
+	String accessToken;
+	String refreshToken;
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/config/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "4004", "토큰이 유효하지 않습니다."),
 	EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "4005", "토큰이 만료됐습니다."),
 	NULL_REQUIRED_VALUE(HttpStatus.BAD_REQUEST, "4006", "필수 요청값이 비어있습니다."),
+	INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "4007", "아이디 또는 비밀번호가 올바르지 않습니다."),
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 

## 📝작업 내용

> 기존에는 로그인 성공 시 토큰 값을 반환하고, 로그인 실패 시 오류 메시지를 반환하는 방식이었습니다. 이를 다른 API와 일관된 형식으로 반환하도록 수정하였습니다.

