### PR TITLE
feat: made it to reuse emails already registered at finance api db

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiService.java
@@ -2,6 +2,7 @@ package com.ssafy.shinhanflow.util;
 
 import org.springframework.stereotype.Service;
 
+import com.ssafy.shinhanflow.config.error.exception.FinanceApiException;
 import com.ssafy.shinhanflow.dto.finance.MemberRequestDto;
 import com.ssafy.shinhanflow.dto.finance.MemberResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountBalanceRequestDto;
@@ -34,7 +35,15 @@ public class FinanceApiService {
 	private final FinanceApiFetcher financeApiFetcher;
 
 	public MemberResponseDto createMember(MemberRequestDto memberRequestDto) {
-		return financeApiFetcher.fetch("/member", memberRequestDto, MemberResponseDto.class);
+		try {
+			return financeApiFetcher.fetch("/member", memberRequestDto, MemberResponseDto.class);
+
+		} catch (FinanceApiException e) {
+			if (e.getErrorCode().equals("E4002")) {
+				return financeApiFetcher.fetch("/member/search", memberRequestDto, MemberResponseDto.class);
+			} else
+				throw e;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## #️⃣연관된 이슈

> #96 

## 📝작업 내용

> 금융망 api에 입력된 이메일 재활용 가능해졌습니다. 다만 db에도 이미 존재하는 경우 에러를 띄웁니다.


## 💬리뷰 요구사항(선택)

> 
