### PR TITLE
feat: 금융api 수시입출금 계좌 삭제 구현

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/finance/CurrentAccountController.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/finance/CurrentAccountController.java
@@ -1,5 +1,6 @@
 package com.ssafy.shinhanflow.controller.finance;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ssafy.shinhanflow.auth.jwt.JWTUtil;
 import com.ssafy.shinhanflow.config.error.SuccessResponse;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountBalanceResponseDto;
+import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDeleteRequestDto;
+import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDeleteResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDepositRequestDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDepositResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountHolderResponseDto;
@@ -134,6 +137,17 @@ public class CurrentAccountController {
 		return SuccessResponse.of(
 			currentAccountService.currentAccountTransactionHistory(jwtUtil.getId(token), accountNo, dto.getStartDate(),
 				dto.getEndDate(), dto.getTransactionType(), dto.getOrderByType()));
+	}
+
+	/**
+	 * 수시 입출금 계좌 삭제
+	 */
+	@DeleteMapping()
+	public SuccessResponse<CurrentAccountDeleteResponseDto> deleteCurrentAccount(
+		@RequestHeader("Authorization") String token,
+		@RequestBody CurrentAccountDeleteRequestDto dto) {
+		return SuccessResponse.of(currentAccountService.deleteCurrentAccount(jwtUtil.getId(token), dto));
+
 	}
 
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/finance/CurrentAccountController.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/finance/CurrentAccountController.java
@@ -129,14 +129,12 @@ public class CurrentAccountController {
 	/**
 	 * 수시 입출금 계좌 거래 내역 조회
 	 */
-	@PostMapping("/{accountNo}/transaction-history")
+	@PostMapping("/transaction-history")
 	public SuccessResponse<CurrentAccountTransactionHistoryResponseDto> currentAccountTransactionHistory(
 		@RequestHeader("Authorization") String token,
-		@PathVariable String accountNo,
 		@RequestBody CurrentAccountTransactionHistoryRequestDto dto) {
 		return SuccessResponse.of(
-			currentAccountService.currentAccountTransactionHistory(jwtUtil.getId(token), accountNo, dto.getStartDate(),
-				dto.getEndDate(), dto.getTransactionType(), dto.getOrderByType()));
+			currentAccountService.currentAccountTransactionHistory(jwtUtil.getId(token), dto));
 	}
 
 	/**

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/finance/current/CurrentAccountDeleteRequestDto.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/finance/current/CurrentAccountDeleteRequestDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.shinhanflow.dto.finance.current;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.shinhanflow.dto.finance.FinanceApiRequestDto;
+import com.ssafy.shinhanflow.dto.finance.header.RequestHeaderDto;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+@Builder
+public class CurrentAccountDeleteRequestDto extends FinanceApiRequestDto {
+	@JsonProperty("Header")
+	RequestHeaderDto header;
+	String accountNo;
+	String refundAccountNo;
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/finance/current/CurrentAccountDeleteResponseDto.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/finance/current/CurrentAccountDeleteResponseDto.java
@@ -1,0 +1,16 @@
+package com.ssafy.shinhanflow.dto.finance.current;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.shinhanflow.dto.finance.FinanceApiResponseDto;
+import com.ssafy.shinhanflow.dto.finance.header.ResponseHeaderDto;
+
+public class CurrentAccountDeleteResponseDto extends FinanceApiResponseDto {
+	@JsonProperty("Header")
+	ResponseHeaderDto header;
+
+	@JsonProperty("REC")
+	Rec rec;
+
+	private record Rec(String status, String accountNo, String refundAccountNo, long accountBalance) {
+	}
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/finance/CurrentAccountService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/finance/CurrentAccountService.java
@@ -204,11 +204,10 @@ public class CurrentAccountService {
 		return financeApiFetcher.currentAccountListInfo(dto);
 	}
 
-	public CurrentAccountTransactionHistoryResponseDto currentAccountTransactionHistory(long userId, String accountNo,
-		String startDate, String endDate, String transactionType,
-		String orderByType) {
+	public CurrentAccountTransactionHistoryResponseDto currentAccountTransactionHistory(long userId,
+		CurrentAccountTransactionHistoryRequestDto dto) {
 		log.info("currentAccountTransactionHistory - userId: {}, accountNo: {}, startDate: {}, endDate: {}", userId,
-			accountNo, startDate, endDate);
+			dto.getAccountNo(), dto.getStartDate(), dto.getEndDate());
 		MemberEntity memberEntity = findMemberOrThrow(userId);
 
 		String userKey = memberEntity.getUserKey();
@@ -216,16 +215,17 @@ public class CurrentAccountService {
 
 		RequestHeaderDto header = financeApiHeaderGenerator.createHeader("inquireTransactionHistoryList", userKey,
 			institutionCode);
-		CurrentAccountTransactionHistoryRequestDto dto = CurrentAccountTransactionHistoryRequestDto.builder()
+
+		CurrentAccountTransactionHistoryRequestDto requestDto = CurrentAccountTransactionHistoryRequestDto.builder()
 			.header(header)
-			.accountNo(accountNo)
-			.startDate(startDate)
-			.endDate(endDate)
-			.transactionType(transactionType)
-			.orderByType(orderByType)
+			.accountNo(dto.getAccountNo())
+			.startDate(dto.getStartDate())
+			.endDate(dto.getEndDate())
+			.transactionType(dto.getTransactionType())
+			.orderByType(dto.getOrderByType())
 			.build();
 
-		return financeApiFetcher.currentAccountTransactionHistory(dto);
+		return financeApiFetcher.currentAccountTransactionHistory(requestDto);
 	}
 
 	/**

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/finance/CurrentAccountService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/finance/CurrentAccountService.java
@@ -9,6 +9,8 @@ import com.ssafy.shinhanflow.config.error.exception.BadRequestException;
 import com.ssafy.shinhanflow.domain.entity.MemberEntity;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountBalanceRequestDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountBalanceResponseDto;
+import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDeleteRequestDto;
+import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDeleteResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDepositRequestDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDepositResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountHolderRequestDto;
@@ -224,6 +226,29 @@ public class CurrentAccountService {
 			.build();
 
 		return financeApiFetcher.currentAccountTransactionHistory(dto);
+	}
+
+	/**
+	 * 수시 입출금 계좌 삭제
+	 */
+	public CurrentAccountDeleteResponseDto deleteCurrentAccount(long userId, CurrentAccountDeleteRequestDto dto) {
+		log.info("deleteCurrentAccount - userId: {}", userId);
+		log.info("계좌번호: {}", dto.getAccountNo());
+
+		MemberEntity memberEntity = findMemberOrThrow(userId);
+
+		String userKey = memberEntity.getUserKey();
+		String institutionCode = memberEntity.getInstitutionCode();
+
+		RequestHeaderDto header = financeApiHeaderGenerator.createHeader("deleteDemandDepositAccount", userKey,
+			institutionCode);
+		CurrentAccountDeleteRequestDto requestDto = CurrentAccountDeleteRequestDto.builder()
+			.header(header)
+			.accountNo(dto.getAccountNo())
+			.refundAccountNo(dto.getRefundAccountNo())
+			.build();
+
+		return financeApiFetcher.deleteCurrentAccount(requestDto);
 	}
 
 	private MemberEntity findMemberOrThrow(long userId) {

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/util/FinanceApiService.java
@@ -7,6 +7,8 @@ import com.ssafy.shinhanflow.dto.finance.MemberRequestDto;
 import com.ssafy.shinhanflow.dto.finance.MemberResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountBalanceRequestDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountBalanceResponseDto;
+import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDeleteRequestDto;
+import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDeleteResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDepositRequestDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountDepositResponseDto;
 import com.ssafy.shinhanflow.dto.finance.current.CurrentAccountHolderRequestDto;
@@ -181,5 +183,10 @@ public class FinanceApiService {
 	 */
 	public ExchangeResponseDto exchange(ExchangeRequestDto dto) {
 		return financeApiFetcher.fetch("/edu/exchange", dto, ExchangeResponseDto.class);
+	}
+
+	public CurrentAccountDeleteResponseDto deleteCurrentAccount(CurrentAccountDeleteRequestDto dto) {
+		return financeApiFetcher.fetch("/edu/demandDeposit/deleteDemandDepositAccount", dto,
+			CurrentAccountDeleteResponseDto.class);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #133 

## 📝작업 내용

> 수시입출금 계좌 삭제 기능을 추가하였습니다.
그리고 거래 내역 조회 메서드이 url과 내부 dto 구조를 수정하였습니다.

