### PR TITLE
refactor: 환율 조회 api 신용정보 조회 api 리팩토링

### DIFF
--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/finance/ExchangeRateController.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/finance/ExchangeRateController.java
@@ -1,11 +1,14 @@
 package com.ssafy.shinhanflow.controller.finance;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ssafy.shinhanflow.config.error.SuccessResponse;
+import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRateDto;
 import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRateResponseDto;
 import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRatesResponseDto;
 import com.ssafy.shinhanflow.service.finance.ExchangeRateService;
@@ -21,9 +24,17 @@ public class ExchangeRateController {
 	private final ExchangeRateService exchangeRateService;
 
 	/**
-	 * 환율 조회
+	 * 금융망 API 가 아닌 DB 에서 환율 조회
 	 */
 	@GetMapping()
+	public SuccessResponse<List<ExchangeRateDto>> exchangeRatesFromDB() {
+		return SuccessResponse.of(exchangeRateService.getExchangeRatesFromDB());
+	}
+
+	/**
+	 * 환율 조회
+	 */
+	// @GetMapping()
 	public SuccessResponse<ExchangeRatesResponseDto> exchangeRates() {
 		return SuccessResponse.of(exchangeRateService.getExchangeRates());
 	}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/member/MemberController.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/controller/member/MemberController.java
@@ -25,9 +25,14 @@ public class MemberController {
 		return SuccessResponse.of(memberService.createMember(signUpRequestDto));
 	}
 
-	@GetMapping("/credit-score")
+	// @GetMapping("/credit-score")
 	public SuccessResponse<CreditScoreResponseDto> getCreditScore(@RequestHeader("Authorization") String token) {
 		return SuccessResponse.of(memberService.getCreditScore(token));
+	}
+
+	@GetMapping("/credit-score")
+	public SuccessResponse<CreditScoreResponseDto> getCreditScoreFromDB(@RequestHeader("Authorization") String token) {
+		return SuccessResponse.of(memberService.getCreditScoreFromDB(token));
 	}
 }
 

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/CreditScoreEntity.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/CreditScoreEntity.java
@@ -1,14 +1,17 @@
 package com.ssafy.shinhanflow.domain.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,24 +21,42 @@ public class CreditScoreEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@NotNull
+	// @NotNull
 	@Column(name = "member_id")
 	private Long memberId;
 
-	@NotNull
+	// @NotNull
+	@Setter
 	@Column(name = "rating_name")
 	private String ratingName;
 
-	@NotNull
+	// @NotNull
+	@Setter
 	@Column(name = "demand_deposit_asset_value")
 	private Long demandDepositAssetValue;
 
-	@NotNull
+	// @NotNull
+	@Setter
 	@Column(name = "deposit_savings_asset_value")
 	private Long depositSavingsAssetValue;
 
-	@NotNull
+	// @NotNull
+	@Setter
 	@Column(name = "total_asset_value")
 	private Long totalAssetValue;
 
+	@Setter
+	@Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+	private LocalDateTime updatedAt;
+
+	@Builder
+	public CreditScoreEntity(String ratingName, Long demandDepositAssetValue, Long depositSavingsAssetValue,
+		Long totalAssetValue, Long memberId) {
+		this.ratingName = ratingName;
+		this.demandDepositAssetValue = demandDepositAssetValue;
+		this.depositSavingsAssetValue = depositSavingsAssetValue;
+		this.totalAssetValue = totalAssetValue;
+		this.memberId = memberId;
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/CreditScoreEntity.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/CreditScoreEntity.java
@@ -2,16 +2,18 @@ package com.ssafy.shinhanflow.domain.entity;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,37 +23,43 @@ public class CreditScoreEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// @NotNull
+	@NotNull
 	@Column(name = "member_id")
 	private Long memberId;
 
-	// @NotNull
-	@Setter
+	@NotNull
 	@Column(name = "rating_name")
 	private String ratingName;
 
-	// @NotNull
-	@Setter
+	@NotNull
 	@Column(name = "demand_deposit_asset_value")
 	private Long demandDepositAssetValue;
 
-	// @NotNull
-	@Setter
+	@NotNull
 	@Column(name = "deposit_savings_asset_value")
 	private Long depositSavingsAssetValue;
 
-	// @NotNull
-	@Setter
+	@NotNull
 	@Column(name = "total_asset_value")
 	private Long totalAssetValue;
 
-	@Setter
-	@Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+	@ColumnDefault("CURRENT_TIMESTAMP")
+	@Column(name = "created_at", nullable = false, insertable = false, updatable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime createdAt;
+
+	@ColumnDefault("CURRENT_TIMESTAMP")
+	@Column(name = "updated_at", nullable = false, insertable = false, columnDefinition = "TIMESTAMP")
 	private LocalDateTime updatedAt;
 
+	@ColumnDefault("NULL")
+	@Column(name = "deleted_at", insertable = false, columnDefinition = "TIMESTAMP")
+	private LocalDateTime deletedAt;
+
 	@Builder
-	public CreditScoreEntity(String ratingName, Long demandDepositAssetValue, Long depositSavingsAssetValue,
-		Long totalAssetValue, Long memberId) {
+	public CreditScoreEntity(Long id, Long memberId, String ratingName, Long demandDepositAssetValue,
+		Long depositSavingsAssetValue,
+		Long totalAssetValue) {
+		this.id = id;
 		this.ratingName = ratingName;
 		this.demandDepositAssetValue = demandDepositAssetValue;
 		this.depositSavingsAssetValue = depositSavingsAssetValue;

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/CreditScoreEntity.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/CreditScoreEntity.java
@@ -1,0 +1,41 @@
+package com.ssafy.shinhanflow.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "Credit_score")
+public class CreditScoreEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull
+	@Column(name = "member_id")
+	private Long memberId;
+
+	@NotNull
+	@Column(name = "rating_name")
+	private String ratingName;
+
+	@NotNull
+	@Column(name = "demand_deposit_asset_value")
+	private Long demandDepositAssetValue;
+
+	@NotNull
+	@Column(name = "deposit_savings_asset_value")
+	private Long depositSavingsAssetValue;
+
+	@NotNull
+	@Column(name = "total_asset_value")
+	private Long totalAssetValue;
+
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/ExchangeRateEntity.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/entity/ExchangeRateEntity.java
@@ -1,0 +1,38 @@
+package com.ssafy.shinhanflow.domain.entity;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Table(name = "exchange_rates")
+public class ExchangeRateEntity {
+
+	@Id
+	@NotNull
+	@Column(name = "currency")
+	private String currency;
+
+	@NotNull
+	@Setter
+	@Column(name = "exchange_rate")
+	private BigDecimal exchangeRate;
+
+	@NotNull
+	@Setter
+	@Column(name = "exchange_min")
+	private BigDecimal exchangeMin;
+
+	@NotNull
+	@Setter
+	@Column(name = "created")
+	private String created;
+
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/trigger/time/SpecificTimeTrigger.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/domain/trigger/time/SpecificTimeTrigger.java
@@ -16,6 +16,6 @@ public record SpecificTimeTrigger(
 	@Override
 	public boolean isTriggered(FinanceTriggerService financeTriggerService, Long userId) {
 		LocalTime now = LocalTime.now();
-		return this.time.getHour() == now.getHour();
+		return this.time.getHour() == now.getHour() && this.time.getMinute() == now.getMinute();
 	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/finance/exchange/ExchangeRateDto.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/finance/exchange/ExchangeRateDto.java
@@ -1,0 +1,15 @@
+package com.ssafy.shinhanflow.dto.finance.exchange;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Builder
+@Value
+public class ExchangeRateDto {
+	String currency;
+	BigDecimal exchangeRate;
+	BigDecimal exchangeMin;
+	String created;
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/member/CreditScoreResponseDto.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/dto/member/CreditScoreResponseDto.java
@@ -4,6 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ssafy.shinhanflow.dto.finance.FinanceApiResponseDto;
 import com.ssafy.shinhanflow.dto.finance.header.RequestHeaderDto;
 
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+@Builder
 public class CreditScoreResponseDto extends FinanceApiResponseDto {
 	@JsonProperty("Header")
 	RequestHeaderDto requestHeader;
@@ -11,7 +18,7 @@ public class CreditScoreResponseDto extends FinanceApiResponseDto {
 	@JsonProperty("REC")
 	Rec rec;
 
-	private record Rec(String ratingName, Long demandDepositAssetValue, Long depositSavingsAssetValue,
-					   Long totalAssetValue) {
+	public record Rec(String ratingName, Long demandDepositAssetValue, Long depositSavingsAssetValue,
+					  Long totalAssetValue) {
 	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/repository/CreditScoreRepository.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/repository/CreditScoreRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.shinhanflow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ssafy.shinhanflow.domain.entity.CreditScoreEntity;
+
+public interface CreditScoreRepository extends JpaRepository<CreditScoreEntity, Long> {
+	CreditScoreEntity findByMemberId(Long memberId);
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/repository/ExchangeRateRepository.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/repository/ExchangeRateRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.shinhanflow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ssafy.shinhanflow.domain.entity.ExchangeRateEntity;
+
+public interface ExchangeRateRepository extends JpaRepository<ExchangeRateEntity, Long> {
+	ExchangeRateEntity findByCurrency(String currency);
+}

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/scheduler/DateScheduler.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/scheduler/DateScheduler.java
@@ -4,6 +4,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.ssafy.shinhanflow.repository.TriggerRepository;
+import com.ssafy.shinhanflow.service.finance.ExchangeRateService;
 import com.ssafy.shinhanflow.util.TriggerChecker;
 
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,21 @@ public class DateScheduler {
 
 	private final TriggerChecker triggerChecker;
 	private final TriggerRepository triggerRepository;
+	private final ExchangeRateService exchangeRateService;
 
 	@Scheduled(cron = "*/5 * * * * *")
 	public void checkDateTrigger() {
 		triggerChecker.run();
+	}
+
+	/**
+	 * 환율 업데이트
+	 * 현재 금융망 API의 경우 매 6분 45초경에 환율 정보가 초기화됨
+	 * 따라서 매 7분 마다 환율 정보를 가저오도록 스케줄링함
+	 */
+	@Scheduled(cron = "0 7,17,27,37,47,57 * * * *")
+	public void updateExchangeRates() {
+		exchangeRateService.updateExchangeRates();
 	}
 
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/finance/ExchangeRateService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/finance/ExchangeRateService.java
@@ -1,14 +1,20 @@
 package com.ssafy.shinhanflow.service.finance;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.ssafy.shinhanflow.config.error.ErrorCode;
 import com.ssafy.shinhanflow.config.error.exception.BadRequestException;
+import com.ssafy.shinhanflow.domain.entity.ExchangeRateEntity;
+import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRateDto;
 import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRateRequestDto;
 import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRateResponseDto;
 import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRatesRequestDto;
 import com.ssafy.shinhanflow.dto.finance.exchange.ExchangeRatesResponseDto;
 import com.ssafy.shinhanflow.dto.finance.header.RequestHeaderDto;
+import com.ssafy.shinhanflow.repository.ExchangeRateRepository;
 import com.ssafy.shinhanflow.repository.MemberRepository;
 import com.ssafy.shinhanflow.util.FinanceApiHeaderGenerator;
 import com.ssafy.shinhanflow.util.FinanceApiService;
@@ -24,6 +30,7 @@ public class ExchangeRateService {
 	private final FinanceApiService financeApiService;
 	private final MemberRepository memberRepository;
 	private final FinanceApiHeaderGenerator financeApiHeaderGenerator;
+	private final ExchangeRateRepository exchangeRateRepository;
 
 	public ExchangeRatesResponseDto getExchangeRates() {
 		log.info("getExchangeRates");
@@ -51,5 +58,49 @@ public class ExchangeRateService {
 			.build();
 
 		return financeApiService.getExchangeRate(dto);
+	}
+
+	/**
+	 * 우리 서비스 DB 에서 환율 조회 메서드
+	 */
+	public List<ExchangeRateDto> getExchangeRatesFromDB() {
+		log.info("getExchangeRatesFromDB 호출");
+		List<ExchangeRateEntity> exchangeRateList = exchangeRateRepository.findAll();
+
+		List<ExchangeRateDto> list = new ArrayList<>();
+
+		exchangeRateList.forEach(exchangeRate -> {
+			ExchangeRateDto dto = ExchangeRateDto.builder()
+				.currency(exchangeRate.getCurrency())
+				.exchangeRate(exchangeRate.getExchangeRate())
+				.exchangeMin(exchangeRate.getExchangeMin())
+				.created(exchangeRate.getCreated())
+				.build();
+			list.add(dto);
+		});
+		return list;
+	}
+
+	/**
+	 * 환율 정보 최신화 메서드
+	 */
+	public void updateExchangeRates() {
+		log.info("데이터베이스 환율 정보 최신화 실행");
+
+		RequestHeaderDto header = financeApiHeaderGenerator.createHeader("exchangeRate", null, "00100");
+		ExchangeRatesRequestDto dto = ExchangeRatesRequestDto.builder()
+			.header(header)
+			.build();
+
+		// 황율 정보를 가저와서 서비스 DB 에 저장
+		List<ExchangeRatesResponseDto.ExchangeRate> exchangeRates = financeApiService.getExchangeRates(dto).getRec();
+		exchangeRates.forEach(rate -> {
+			ExchangeRateEntity entity = exchangeRateRepository.findByCurrency(rate.getCurrency());
+			entity.setExchangeRate(rate.getExchangeRate());
+			entity.setExchangeMin(rate.getExchangeMin());
+			entity.setCreated(rate.getCreated());
+
+			exchangeRateRepository.save(entity);
+		});
 	}
 }

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/member/MemberService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.ssafy.shinhanflow.service.member;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +10,7 @@ import com.ssafy.shinhanflow.auth.jwt.JWTUtil;
 import com.ssafy.shinhanflow.config.SecurityConfig;
 import com.ssafy.shinhanflow.config.error.ErrorCode;
 import com.ssafy.shinhanflow.config.error.exception.BadRequestException;
+import com.ssafy.shinhanflow.domain.entity.CreditScoreEntity;
 import com.ssafy.shinhanflow.domain.entity.MemberEntity;
 import com.ssafy.shinhanflow.dto.finance.MemberRequestDto;
 import com.ssafy.shinhanflow.dto.finance.MemberResponseDto;
@@ -16,14 +18,17 @@ import com.ssafy.shinhanflow.dto.finance.header.RequestHeaderDto;
 import com.ssafy.shinhanflow.dto.member.CreditScoreRequestDto;
 import com.ssafy.shinhanflow.dto.member.CreditScoreResponseDto;
 import com.ssafy.shinhanflow.dto.member.SignUpRequestDto;
+import com.ssafy.shinhanflow.repository.CreditScoreRepository;
 import com.ssafy.shinhanflow.repository.MemberRepository;
 import com.ssafy.shinhanflow.util.FinanceApiHeaderGenerator;
 import com.ssafy.shinhanflow.util.FinanceApiService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class MemberService {
 	@Value("${finance-api.key}")
 	private String apiKey;
@@ -32,6 +37,7 @@ public class MemberService {
 	private final SecurityConfig securityConfig;
 	private final FinanceApiHeaderGenerator financeApiHeaderGenerator;
 	private final JWTUtil jwtUtil;
+	private final CreditScoreRepository creditScoreRepository;
 
 	public Boolean createMember(SignUpRequestDto signUpRequestDto) {
 		// communicate with finance api
@@ -61,6 +67,52 @@ public class MemberService {
 			.header(header)
 			.build();
 		return financeApiFetcher.getCreditScore(dto);
+	}
+
+	public CreditScoreResponseDto getCreditScoreFromDB(String token) {
+		CreditScoreResponseDto creditScore;
+		long userId = jwtUtil.getId(token);
+		MemberEntity memberEntity = findMemberOrThrow(userId);
+
+		String userKey = memberEntity.getUserKey();
+		String institutionCode = memberEntity.getInstitutionCode();
+		LocalDateTime now = LocalDateTime.now();
+
+		CreditScoreEntity creditScoreEntity = creditScoreRepository.findByMemberId(userId);
+		// 우리 데이터베이스에 없거나 updateAt 이 하루 이상 지난 경우
+		if (creditScoreEntity == null || creditScoreEntity.getUpdatedAt().plusDays(1).isBefore(now)) {
+			creditScore = getCreditScore(token); // finance api 에서 조회
+			if (creditScoreEntity == null) {
+				log.info("creditScoreEntity is null");
+				log.info("userId : {}", userId);
+				// 데이터베이스에 새로 저장
+				creditScoreEntity = creditScoreEntity.builder()
+					.ratingName(creditScore.getRec().ratingName())
+					.demandDepositAssetValue(creditScore.getRec().demandDepositAssetValue())
+					.depositSavingsAssetValue(creditScore.getRec().depositSavingsAssetValue())
+					.totalAssetValue(creditScore.getRec().totalAssetValue())
+					.memberId(userId)
+					.build();
+			} else {
+				log.info("creditScoreEntity is not null");
+				// 데이터베이스에 업데이트
+				creditScoreEntity.setRatingName(creditScore.getRec().ratingName());
+				creditScoreEntity.setDemandDepositAssetValue(creditScore.getRec().demandDepositAssetValue());
+				creditScoreEntity.setDepositSavingsAssetValue(creditScore.getRec().depositSavingsAssetValue());
+				creditScoreEntity.setTotalAssetValue(creditScore.getRec().totalAssetValue());
+				creditScoreEntity.setUpdatedAt(now);
+			}
+			log.info("2. creditScoreEntity: {}", creditScoreEntity.toString());
+			creditScoreRepository.save(creditScoreEntity);
+		} else {
+			// 우리 데이터베이스에서 조회
+			creditScore = CreditScoreResponseDto.builder()
+				.rec(new CreditScoreResponseDto.Rec(creditScoreEntity.getRatingName(),
+					creditScoreEntity.getDemandDepositAssetValue(), creditScoreEntity.getDepositSavingsAssetValue(),
+					creditScoreEntity.getTotalAssetValue()))
+				.build();
+		}
+		return creditScore;
 	}
 
 	private MemberEntity findMemberOrThrow(long userId) {

--- a/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/member/MemberService.java
+++ b/be/ShinhanFlow/src/main/java/com/ssafy/shinhanflow/service/member/MemberService.java
@@ -81,28 +81,17 @@ public class MemberService {
 		CreditScoreEntity creditScoreEntity = creditScoreRepository.findByMemberId(userId);
 		// 우리 데이터베이스에 없거나 updateAt 이 하루 이상 지난 경우
 		if (creditScoreEntity == null || creditScoreEntity.getUpdatedAt().plusDays(1).isBefore(now)) {
-			creditScore = getCreditScore(token); // finance api 에서 조회
-			if (creditScoreEntity == null) {
-				log.info("creditScoreEntity is null");
-				log.info("userId : {}", userId);
-				// 데이터베이스에 새로 저장
-				creditScoreEntity = creditScoreEntity.builder()
-					.ratingName(creditScore.getRec().ratingName())
-					.demandDepositAssetValue(creditScore.getRec().demandDepositAssetValue())
-					.depositSavingsAssetValue(creditScore.getRec().depositSavingsAssetValue())
-					.totalAssetValue(creditScore.getRec().totalAssetValue())
-					.memberId(userId)
-					.build();
-			} else {
-				log.info("creditScoreEntity is not null");
-				// 데이터베이스에 업데이트
-				creditScoreEntity.setRatingName(creditScore.getRec().ratingName());
-				creditScoreEntity.setDemandDepositAssetValue(creditScore.getRec().demandDepositAssetValue());
-				creditScoreEntity.setDepositSavingsAssetValue(creditScore.getRec().depositSavingsAssetValue());
-				creditScoreEntity.setTotalAssetValue(creditScore.getRec().totalAssetValue());
-				creditScoreEntity.setUpdatedAt(now);
-			}
-			log.info("2. creditScoreEntity: {}", creditScoreEntity.toString());
+			// finance api 에서 조회
+			creditScore = getCreditScore(token);
+			// 우리 데이터베이스에 저장 및 업데이트
+			creditScoreEntity = creditScoreEntity.builder()
+				.id(userId)
+				.ratingName(creditScore.getRec().ratingName())
+				.demandDepositAssetValue(creditScore.getRec().demandDepositAssetValue())
+				.depositSavingsAssetValue(creditScore.getRec().depositSavingsAssetValue())
+				.totalAssetValue(creditScore.getRec().totalAssetValue())
+				.memberId(userId)
+				.build();
 			creditScoreRepository.save(creditScoreEntity);
 		} else {
 			// 우리 데이터베이스에서 조회


### PR DESCRIPTION
## #️⃣연관된 이슈

> #169 

## 📝작업 내용

> 환율 조회 api, 신용정보 조회 api 리팩토링
현재 환율 조회 API와 신용정보 조회 API는 매번 금융망 API에 요청을 보내는 방식으로 작동하고 있습니다. 이로 인해 사용자 요청이 많아질 경우, 메인 시스템에 과도한 부하가 발생할 수 있습니다.
이 문제를 개선하기 위해, 환율 정보와 사용자의 신용 정보를 저희 서비스의 데이터베이스에 1차적으로 저장하고, 최신화가 필요할 때에만 금융망 API를 호출하는 방식으로 변경하려고 합니다. 이를 통해 메인 시스템의 부하를 최소화하고, 효율성을 높일 수 있을것으로 기대됩니다.

